### PR TITLE
Add Net2+ configuration documentation

### DIFF
--- a/docs/dwprox/net2/config.md
+++ b/docs/dwprox/net2/config.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 2
+sidebar_title: config
+sidebar_label: Configuration
+---
+
+# Configuration
+
+:::info
+
+Download the recent available file for this product via [Axon](https://axon.whitehill.club).
+
+:::
+
+### 1) Insert the model into your game {#1}
+In ROBLOX Studio, open your game and drag and drop the model, for detailed installation instructions, please visit the previous page.
+
+### 2) Copy the new accessories {#2}
+Depending on what accessories you would like to add, you can find the majority of pre-made ones in the original model you inserted into the game. For example, you will find a doorbell, an alternative push to exit button, and alternative reader models for you to choose from.
+
+Once you have selected your reader, copy it by right clicking on the model
+
+:::info
+
+You can also download our K50 Keypad from [Axon](https://axon.whitehill.club/api/download/PaxtonK50).
+
+:::
+
+### 3) Paste into the correct door {#3}
+Once you have copied your chosen accessories, you can just paste them into your Net2+ Model by navigating to your door model -> DWProx Net2+ and depending on what you have copied, pasting into the correct folder (Bell / Buttons / Readers).
+
+### 4) Product Configuration {#4}
+Please be aware there are 2 main configuration files, One named 'Settings' allowing for configuration of the door such as modes and speeds, With the 'PaxtonSettings' script allowing for configuration of the access control system. Each device also includes its own configuration file allowing for device-specific configuration. 
+
+:::info
+
+If require more assistance, please make a ticket in our [Discord server](https://whitehill.club/discord) (13+)
+
+:::

--- a/docs/dwprox/net2/net2.md
+++ b/docs/dwprox/net2/net2.md
@@ -25,9 +25,6 @@ There are a number of reasons your doors may not be working correctly. These inc
 
 :::
 
-### 4) Product Configuration {#4}
-Please be aware there are 2 main configuration files, One named 'Settings' allowing for configuration of the door such as modes and speeds, With the 'PaxtonSettings' script allowing for configuration of the access control system. Each device also includes its own configuration file allowing for device-specific configuration. 
-
 :::info
 
 If require more assistance, please make a ticket in our [Discord server](https://whitehill.club/discord) (13+)


### PR DESCRIPTION
New file, config.md, which contains detailed instructions for configuring Paxton Net2+ and installing new readers / buttons